### PR TITLE
Parsing new mechanics for v0.4

### DIFF
--- a/src/main/scala/wordbots/CodeGenerator.scala
+++ b/src/main/scala/wordbots/CodeGenerator.scala
@@ -17,9 +17,13 @@ object CodeGenerator {
       case Destroy(target) => s"(function () { actions['destroy'](${g(target)}); })"
       case Discard(target) => s"(function () { actions['discard'](${g(target)}); })"
       case Draw(target, num) => s"(function () { actions['draw'](${g(target)}, ${g(num)}); })"
+      case EndTurn => "(function () { actions['endTurn'](); })"
+      case GiveAbility(target, ability) => s"""(function () { actions['giveAbility'](${g(target)}, \\"${g(ability)}\\"); })"""
       case ModifyAttribute(target, attr, op) => s"(function () { actions['modifyAttribute'](${g(target)}, ${g(attr)}, ${g(op)}); })"
       case ModifyEnergy(target, op) => s"(function () { actions['modifyEnergy'](${g(target)}, ${g(op)}); })"
+      case RestoreHealth(target) => s"(function () { actions['restoreHealth'](${g(target)}); })"
       case SetAttribute(target, attr, num) => s"(function () { actions['setAttribute'](${g(target)}, ${g(attr)}, ${g(num)}); })"
+      case SwapAttributes(target, attr1, attr2) => s"(function () { actions['swapAttributes'](${g(target)}, ${g(attr1)}, ${g(attr2)}); })"
       case TakeControl(player, target) => s"(function () { actions['takeControl'](${g(player)}, ${g(target)}); })"
 
       // Actions: Utility
@@ -38,7 +42,7 @@ object CodeGenerator {
         s"(function () { setAbility(abilities['attributeAdjustment'](function () { return ${g(target)}; }, ${g(attr)}, ${g(op)})); })"
       case FreezeAttribute(target, attr) =>
         s"(function () { setAbility(abilities['freezeAttribute'](function () { return ${g(target)}; }, ${g(attr)})); })"
-      case GiveAbility(target, ability) =>
+      case HasAbility(target, ability) =>
         s"""(function () { setAbility(abilities['giveAbility'](function () { return ${g(target)}; }, \\"${g(ability)}\\")); })"""
 
       // Effects
@@ -49,6 +53,7 @@ object CodeGenerator {
       case AfterCardPlay(targetPlayer, cardType) => s"triggers['afterCardPlay'](function () { return ${g(targetPlayer)}; }, ${g(cardType)})"
       case AfterDamageReceived(targetObj) => s"triggers['afterDamageReceived'](function () { return ${g(targetObj)}; })"
       case AfterDestroyed(targetObj, cause) => s"triggers['afterDestroyed'](function () { return ${g(targetObj)}; }, ${g(cause)})"
+      case AfterMove(targetObj) => s"triggers['afterMove'](function () { return ${g(targetObj)}; })"
       case AfterPlayed(targetObj) => s"triggers['afterPlayed'](function () { return ${g(targetObj)}; })"
       case BeginningOfTurn(targetPlayer) => s"triggers['beginningOfTurn'](function () { return ${g(targetPlayer)}; })"
       case EndOfTurn(targetPlayer) => s"triggers['endOfTurn'](function () { return ${g(targetPlayer)}; })"
@@ -72,6 +77,8 @@ object CodeGenerator {
       case AdjacentTo(obj) => s"conditions['adjacentTo'](${g(obj)})"
       case AttributeComparison(attr, comp) => s"conditions['attributeComparison'](${g(attr)}, ${g(comp)})"
       case ControlledBy(player) => s"conditions['controlledBy'](${g(player)})"
+      case HasProperty(property) => s"conditions['hasProperty'](${g(property)})"
+      case WithinDistanceOf(distance: Number, obj: TargetObject) => s"conditions['withinDistanceOf'](${g(distance)}, ${g(obj)})"
 
       // Global conditions
       case CollectionExists(coll) => s"(${g(coll)}.length > 0)"
@@ -93,9 +100,10 @@ object CodeGenerator {
 
       // Numbers
       case Scalar(int) => s"$int"
-      case Count(collection) => s"count(${g(collection)})"
       case AttributeSum(collection, attr) => s"attributeSum(${g(collection)}, ${g(attr)})"
       case AttributeValue(obj, attr) => s"attributeValue(${g(obj)}, ${g(attr)})"
+      case Count(collection) => s"count(${g(collection)})"
+      case EnergyAmount(player) => s"energyAmount(${g(player)})"
 
       // Collections
       case AllTiles => s"allTiles()"

--- a/src/main/scala/wordbots/CodeGenerator.scala
+++ b/src/main/scala/wordbots/CodeGenerator.scala
@@ -108,7 +108,6 @@ object CodeGenerator {
       // Collections
       case AllTiles => s"allTiles()"
       case CardsInHand(player, cardType) => s"cardsInHand(${g(player)}, ${g(cardType)})"
-      case ObjectsInPlay(objType) => s"objectsInPlay(${g(objType)})"
       case ObjectsMatchingConditions(objType, conditions) => s"objectsMatchingConditions(${g(objType)}, ${conditions.map(g).mkString("[", ", ", "]")})"
       case Other(collection) => s"other(${g(collection)})"
 

--- a/src/main/scala/wordbots/Lexicon.scala
+++ b/src/main/scala/wordbots/Lexicon.scala
@@ -101,6 +101,7 @@ object Lexicon {
       (S\NP, λ {c: Choose => AfterDestroyed(All(c.collection))}), // For this and other triggers, replace Choose targets w/ All targets.
       (S\NP, λ {t: TargetObject => AfterDestroyed(t)})
     )) +
+    (Seq("doesn't deal damage when attacked", "only deals damage when attacking") -> (S\NP, λ {t: TargetObject => ApplyEffect(t, CannotFightBack)})) +
     ("draw" -> (S/NP, λ {c: Cards => Draw(Self, c.num)})) +
     ("discard" -> (S/NP, λ {t: TargetObject => Discard(t)})) +
     ("double" -> Seq(
@@ -188,7 +189,7 @@ object Lexicon {
     )) +
     ("must" -> (X/X, identity)) +
     ("number" -> (Num/PP, λ {c: Collection => Count(c)})) +
-    (("object".s :+ "objects'") -> (N, Form(AllObjects): SemanticState)) +
+    (("object".s :+ "objects '") -> (N, Form(AllObjects): SemanticState)) +
     ("of" -> ((S/NP)\V, λ {ops: Seq[AttributeOperation] => λ {t: TargetObject => MultipleActions(Seq(SaveTarget(t)) ++ ops.map(op => ModifyAttribute(SavedTargetObject, op.attr, op.op)))}})) +
     ("other" -> (NP/N, λ {o: ObjectType => Other(ObjectsInPlay(o))})) +
     (Seq("or", "and") -> ((N/N)\N, λ {o1: ObjectType => λ {o2: ObjectType => MultipleObjectTypes(Seq(o1, o2))}})) +
@@ -219,7 +220,7 @@ object Lexicon {
     )) +
     ("reduce" -> (((S/PP)/PP)/N, λ {a: Attribute => λ {t: TargetObject => λ {num: Number => ModifyAttribute(t, a, Minus(num))}}})) +
     ("restore" -> (S/NP, λ {ta: TargetAttribute => ta.attr match { case Health => RestoreHealth(ta.target); case a => Fail(s"Expected Health, got $a")}})) +
-    (("robot".s :+ "robots'") -> Seq(
+    (("robot".s :+ "robots '") -> Seq(
       (N, Form(Robot): SemanticState),
       (NP/PP, λ {hand: Hand => CardsInHand(hand.player, Robot)})  // e.g. "all robots in your hand"
     )) +
@@ -235,7 +236,7 @@ object Lexicon {
       (N\Num, λ {i: Scalar => AttributeAmount(i, Speed)}),
       (NP\Adj, λ {op: Operation => AttributeOperation(op, Speed)})
     )) +
-    (("structure".s :+ "structures'") -> Seq(
+    (("structure".s :+ "structures '") -> Seq(
       (N, Form(Structure): SemanticState),
       (NP/PP, λ {hand: Hand => CardsInHand(hand.player, Structure)})  // e.g. "All structures in your hand"
     )) +
@@ -280,7 +281,7 @@ object Lexicon {
       (NP/NP, λ {c: ObjectsMatchingConditions => ObjectsMatchingConditions(c.objectType, c.conditions :+ ControlledBy(Opponent))}),
       (Adj, Form(Opponent): SemanticState)
     )) +
-    ("'s" -> ((NP\NP)/N, λ {a: Attribute => λ {t: TargetObject => TargetAttribute(t, a)}})) +
+    (Seq("'", "'s") -> ((NP\NP)/N, λ {a: Attribute => λ {t: TargetObject => TargetAttribute(t, a)}})) +
     ("\"" -> Seq(
       (Quoted/S, identity),
       (S\Quoted, identity)

--- a/src/main/scala/wordbots/Parser.scala
+++ b/src/main/scala/wordbots/Parser.scala
@@ -87,6 +87,7 @@ object Parser extends SemanticParser[CcgCat](Lexicon.lexicon) {
   private def tokenizer(str: String): IndexedSeq[String] = {
     str.trim
       .toLowerCase
+      .replaceAllLiterally("\' ", " \' ")
       .replaceAllLiterally("\'s", " \'s ")
       .replaceAllLiterally("\"", " \" ")
       .split("\\s+|[.?!,]")

--- a/src/main/scala/wordbots/Parser.scala
+++ b/src/main/scala/wordbots/Parser.scala
@@ -24,7 +24,7 @@ object Parser extends SemanticParser[CcgCat](Lexicon.lexicon) {
 
     // scalastyle:off regex
     println(s"Input: $input")
-    //println(s"Tokens: ${tokenizer(input).mkString("[\"", "\", \"", "\"]")}")
+    println(s"Tokens: ${tokenizer(input).mkString("[\"", "\", \"", "\"]")}")
     println(s"Parse result: $output")
     println(s"Error diagnosis: ${diagnoseError(input, result.bestParse)}")
     println(s"Generated JS code: $code")
@@ -87,6 +87,7 @@ object Parser extends SemanticParser[CcgCat](Lexicon.lexicon) {
   private def tokenizer(str: String): IndexedSeq[String] = {
     str.trim
       .toLowerCase
+      .replaceAllLiterally("\'s", " \'s ")
       .replaceAllLiterally("\"", " \" ")
       .split("\\s+|[.?!,]")
       .filter("" !=)

--- a/src/main/scala/wordbots/semantics.scala
+++ b/src/main/scala/wordbots/semantics.scala
@@ -106,7 +106,7 @@ sealed trait Collection extends AstNode
     case class CardsInHand(player: TargetPlayer, cardType: CardType = AnyCard) extends CardCollection
   sealed trait ObjectCollection extends Collection with TargetObject
     case object AllTiles extends ObjectCollection
-    case class ObjectsInPlay(objectType: ObjectType) extends ObjectCollection
+    object ObjectsInPlay { def apply(objectType: ObjectType): ObjectCollection = ObjectsMatchingConditions(objectType, Seq()) }
     case class ObjectsMatchingConditions(objectType: ObjectType, conditions: Seq[Condition]) extends ObjectCollection
     case class Other(collection: Collection) extends ObjectCollection
 
@@ -140,12 +140,15 @@ sealed trait Rounding extends Label
   case object RoundedDown extends Rounding
 
 // These container classes are used to store state mid-parse but not expressed in the final parsed AST.
+// Unary container classes:
 case class Cards(num: Number)
 case class Damage(amount: Number)
 case class Energy(amount: Number)
 case class Life(amount: Number)
 case class Hand(player: TargetPlayer)
+case class Spaces(num: Number)
 case class Turn(player: TargetPlayer)
+// Binary container classes:
 case class TargetAttribute(target: TargetObject, attr: Attribute)
 case class AttributeAmount(amount: Number, attr: Attribute)
 case class AttributeOperation(op: Operation, attr: Attribute)

--- a/src/main/scala/wordbots/semantics.scala
+++ b/src/main/scala/wordbots/semantics.scala
@@ -21,9 +21,13 @@ sealed trait Action extends AstNode
   case class Destroy(target: TargetObject) extends Action
   case class Discard(target: TargetObject) extends Action
   case class Draw(target: TargetPlayer, num: Number) extends Action
+  case object EndTurn extends Action
+  case class GiveAbility(target: TargetObject, ability: Ability) extends Action
   case class ModifyAttribute(target: TargetObject, attribute: Attribute, operation: Operation) extends Action
   case class ModifyEnergy(target: TargetPlayer, operation: Operation) extends Action
+  case class RestoreHealth(target: TargetObject) extends Action
   case class SetAttribute(target: TargetObject, attribute: Attribute, num: Number) extends Action
+  case class SwapAttributes(target: TargetObject, attr1: Attribute, attr2: Attribute) extends Action
   case class TakeControl(player: TargetPlayer, target: TargetObject) extends Action
 
   case class SaveTarget(target: Target) extends Action
@@ -32,11 +36,12 @@ sealed trait PassiveAbility extends Ability
   case class ApplyEffect(target: Target, effect: Effect) extends PassiveAbility
   case class AttributeAdjustment(target: Target, attribute: Attribute, operation: Operation) extends PassiveAbility
   case class FreezeAttribute(target: Target, attribute: Attribute) extends PassiveAbility
-  case class GiveAbility(target: Target, ability: Ability) extends PassiveAbility
+  case class HasAbility(target: Target, ability: Ability) extends PassiveAbility
 
 sealed trait Effect extends AstNode
   case object CanMoveOverObjects extends Effect with Label
   case object CannotAttack extends Effect with Label
+  case object CannotFightBack extends Effect with Label
   case class CanOnlyAttack(target: TargetObject) extends Effect
 
 sealed trait Trigger extends AstNode
@@ -44,6 +49,7 @@ sealed trait Trigger extends AstNode
   case class AfterCardPlay(target: TargetPlayer, cardType: CardType = AnyCard) extends Trigger
   case class AfterDamageReceived(target: TargetObject) extends Trigger
   case class AfterDestroyed(target: TargetObject, cause: TriggerEvent = AnyEvent) extends Trigger
+  case class AfterMove(Target: TargetObject) extends Trigger
   case class AfterPlayed(Target: TargetObject) extends Trigger
   case class BeginningOfTurn(player: TargetPlayer) extends Trigger
   case class EndOfTurn(player: TargetPlayer) extends Trigger
@@ -68,6 +74,8 @@ sealed trait Condition extends AstNode
   case class AdjacentTo(obj: TargetObject) extends Condition
   case class AttributeComparison(attribute: Attribute, comparison: Comparison) extends Condition
   case class ControlledBy(player: TargetPlayer) extends Condition
+  case class HasProperty(property: Property) extends Condition
+  case class WithinDistanceOf(distance: Number, obj: TargetObject) extends Condition
 
 sealed trait GlobalCondition extends AstNode
   case class CollectionExists(coll: Collection) extends GlobalCondition
@@ -88,9 +96,10 @@ sealed trait Comparison extends AstNode
 
 sealed trait Number extends AstNode
   case class Scalar(num: Int) extends Number
-  case class Count(collection: Collection) extends Number
   case class AttributeSum(collection: Collection, attribute: Attribute) extends Number
   case class AttributeValue(obj: TargetObject, attribute: Attribute) extends Number
+  case class Count(collection: Collection) extends Number
+  case class EnergyAmount(player: TargetPlayer) extends Number
 
 sealed trait Collection extends AstNode
   sealed trait CardCollection extends Collection
@@ -121,6 +130,10 @@ sealed trait Attribute extends Label
   case object Health extends Attribute
   case object Speed extends Attribute
   case object AllAttributes extends Attribute
+
+sealed trait Property extends Label
+  case object AttackedThisTurn extends Property
+  case object IsDamaged extends Property
 
 sealed trait Rounding extends Label
   case object RoundedUp extends Rounding

--- a/src/test/scala/wordbots/ParserSpec.scala
+++ b/src/test/scala/wordbots/ParserSpec.scala
@@ -215,10 +215,10 @@ class ParserSpec extends FlatSpec with Matchers {
 
     // New terms for alpha v0.4:
     parse("All friendly robots within 2 spaces have +1 speed") shouldEqual
-      AttributeAdjustment(ObjectsMatchingConditions(Robot, Seq(WithinDistanceOf(Scalar(2), ThisObject), ControlledBy(Self))), Speed, Plus(Scalar(1)))
+      AttributeAdjustment(ObjectsMatchingConditions(Robot, Seq(ControlledBy(Self), WithinDistanceOf(Scalar(2), ThisObject))), Speed, Plus(Scalar(1)))
     parse("This robot only deals damage when attacking.") shouldEqual
       ApplyEffect(ThisObject, CannotFightBack)
-    parse("Adjacent robots' attributes can’t be changed.") shouldEqual
+    parse("Adjacent robots' attributes can't be changed.") shouldEqual
       FreezeAttribute(ObjectsMatchingConditions(Robot, Seq(AdjacentTo(ThisObject))), AllAttributes)
   }
 

--- a/src/test/scala/wordbots/ParserSpec.scala
+++ b/src/test/scala/wordbots/ParserSpec.scala
@@ -178,7 +178,7 @@ class ParserSpec extends FlatSpec with Matchers {
     parse("Whenever this robot moves, it takes 1 damage") shouldEqual
       TriggeredAbility(AfterMove(ThisObject), DealDamage(ItO, Scalar(1)))
     parse("Whenever an enemy robot moves, gain 1 life") shouldEqual
-      TriggeredAbility(AfterMove(ObjectsMatchingConditions(Robot, Seq(ControlledBy(Opponent)))), ModifyAttribute(ObjectsMatchingConditions(Kernel, Seq(ControlledBy(Self))), Health, Plus(Scalar(1))))
+      TriggeredAbility(AfterMove(All(ObjectsMatchingConditions(Robot, Seq(ControlledBy(Opponent))))), ModifyAttribute(ObjectsMatchingConditions(Kernel, Seq(ControlledBy(Self))), Health, Plus(Scalar(1))))
     parse("When this robot is played, swap all robots' health and attack.") shouldEqual
       TriggeredAbility(AfterPlayed(ThisObject), SwapAttributes(ObjectsInPlay(Robot), Health, Attack))
     parse("When this robot is destroyed, deal 2 damage to all objects within 2 spaces.") shouldEqual
@@ -235,9 +235,9 @@ class ParserSpec extends FlatSpec with Matchers {
 
   it should "generate JS code for actions" in {
     generateJS("Draw a card") should be ("(function () { actions['draw'](targets['self'](), 1); })")
-    generateJS("Destroy a robot") should be ("(function () { actions['destroy'](targets['choose'](objectsInPlay('robot'))); })")
+    generateJS("Destroy a robot") should be ("(function () { actions['destroy'](targets['choose'](objectsMatchingConditions('robot', []))); })")
     generateJS("Gain 2 energy") should be ("(function () { actions['modifyEnergy'](targets['self'](), function (x) { return x + 2; }); })")
-    generateJS("Give a robot +1 speed") should be ("(function () { actions['modifyAttribute'](targets['choose'](objectsInPlay('robot')), 'speed', function (x) { return x + 1; }); })")
+    generateJS("Give a robot +1 speed") should be ("(function () { actions['modifyAttribute'](targets['choose'](objectsMatchingConditions('robot', [])), 'speed', function (x) { return x + 1; }); })")
   }
 
   it should "disallow choosing targets inside a triggered action, *except* for AfterPlayed triggers" in {


### PR DESCRIPTION
#10, #11, #14, #26, #27, #28.

We can now parse the following:
> “Draw 3 cards, then immediately end your turn.”
> “Deal 1 damage to each robot that attacked last turn.”
> “Destroy a damaged robot.”
> "Draw cards equal to your energy" 
> "Set your opponent's health equal to their energy."
> “Give a robot +1 speed and Jump.”
> “Give a robot “Activate: Deal 1 damage to a random robot.””
> “Whenever this robot moves, it takes 1 damage.”
> “Whenever an enemy robot moves, gain 1 life”
> “When this robot is played, swap all robots’ health and attack.”
> “Shutdown: Deal 2 damage to all objects within 2 spaces.”
> “All friendly robots within 2 spaces have +1 speed”
> “This robot only deals damage when attacking.”
> “This robot’s attributes can’t be changed. Adjacent robots’ attributes can’t be changed.”
> “Activate: Restore an adjacent object’s health.”
