### PR TITLE
Allow TargetAttribute to take a player instead of object

### DIFF
--- a/src/main/scala/wordbots/AstValidator.scala
+++ b/src/main/scala/wordbots/AstValidator.scala
@@ -104,19 +104,6 @@ object NoModifyingCostOfObjects extends AstRule {
   }
 }
 
-object OnlyHealthAttributeForPlayers extends AstRule {
-  override def validate(node: AstNode): Try[Unit] = {
-    node match {
-      case AttributeAdjustment(target, Cost, _) =>
-        target match {
-          case _: TargetObject => Failure(ValidationError("Can't modify the cost of objects on the board."))
-          case _ => validateChildren(this, node)
-        }
-      case n: AstNode => validateChildren(this, n)
-    }
-  }
-}
-
 object OnlyRestoreHealth extends AstRule {
   override def validate(node: AstNode): Try[Unit] = {
     node match {

--- a/src/main/scala/wordbots/AstValidator.scala
+++ b/src/main/scala/wordbots/AstValidator.scala
@@ -104,6 +104,19 @@ object NoModifyingCostOfObjects extends AstRule {
   }
 }
 
+object OnlyHealthAttributeForPlayers extends AstRule {
+  override def validate(node: AstNode): Try[Unit] = {
+    node match {
+      case AttributeAdjustment(target, Cost, _) =>
+        target match {
+          case _: TargetObject => Failure(ValidationError("Can't modify the cost of objects on the board."))
+          case _ => validateChildren(this, node)
+        }
+      case n: AstNode => validateChildren(this, n)
+    }
+  }
+}
+
 object OnlyRestoreHealth extends AstRule {
   override def validate(node: AstNode): Try[Unit] = {
     node match {

--- a/src/main/scala/wordbots/Lexicon.scala
+++ b/src/main/scala/wordbots/Lexicon.scala
@@ -302,8 +302,8 @@ object Lexicon {
     )) +
     ("remove all abilities" -> (S/PP, λ {t: TargetObject => RemoveAllAbilities(t)})) +
     ("restore" -> Seq(
-      ((S/PP)/N, λ {a: Attribute => λ {t: TargetObject => RestoreAttribute(t, a, None)}}),  // e.g. "Restore health to X"
-      (((S/PP)/N)/Num, λ {n: Number => λ {a: Attribute => λ {t: TargetObject => RestoreAttribute(t, a, Some(n))}}}),  // e.g. "Restore N health to X"
+      ((S/PP)/N, λ {a: Attribute => λ {t: TargetObjectOrPlayer => RestoreAttribute(t, a, None)}}),  // e.g. "Restore health to X"
+      (((S/PP)/N)/Num, λ {n: Number => λ {a: Attribute => λ {t: TargetObjectOrPlayer => RestoreAttribute(t, a, Some(n))}}}),  // e.g. "Restore N health to X"
       (S/NP, λ {ta: TargetAttribute => RestoreAttribute(ta.target, ta.attr, None)})  // e.g. "Restore X's health"
     )) +
     ("return" -> ((S/PP)/NP, λ {t: TargetObject => λ {_: ItsOwnersHand.type => ReturnToHand(t)}})) +
@@ -390,7 +390,7 @@ object Lexicon {
       (Adj, Form(Opponent): SemanticState)
     )) +
     (Seq("'", "'s") -> Seq(
-      ((NP\NP)/N, λ {a: Attribute => λ {t: TargetObject => TargetAttribute(t, a)}}),
+      ((NP\NP)/N, λ {a: Attribute => λ {t: TargetObjectOrPlayer => TargetAttribute(t, a)}}),
       ((NP\NP)/N, λ {a: Attribute => λ {t: TargetObject => AttributeValue(t, a)}})
     )) +
     ("\"" -> Seq(

--- a/src/main/scala/wordbots/semantics.scala
+++ b/src/main/scala/wordbots/semantics.scala
@@ -26,14 +26,14 @@ sealed trait Action extends AstNode
   case class Draw(target: TargetPlayer, num: Number) extends Action
   case object EndTurn extends Action
   case class GiveAbility(target: TargetObject, ability: Ability) extends Action
-  case class ModifyAttribute(target: TargetObjectOrCard, attribute: Attribute, operation: Operation) extends Action
+  case class ModifyAttribute(target: Target, attribute: Attribute, operation: Operation) extends Action
   case class ModifyEnergy(target: TargetPlayer, operation: Operation) extends Action
   case class MoveObject(target: TargetObject, dest: TargetObject) extends Action
   case class PayEnergy(target: TargetPlayer, amount: Number) extends Action
   case class RemoveAllAbilities(target: TargetObject) extends Action
   case class ReturnToHand(target: TargetObject) extends Action
-  case class RestoreAttribute(target: TargetObject, attribute: Attribute, num: Option[Number] = None) extends Action
-  case class SetAttribute(target: TargetObject, attribute: Attribute, num: Number) extends Action
+  case class RestoreAttribute(target: TargetObjectOrPlayer, attribute: Attribute, num: Option[Number] = None) extends Action
+  case class SetAttribute(target: TargetObjectOrPlayer, attribute: Attribute, num: Number) extends Action
   case class SwapAttributes(target: TargetObject, attr1: Attribute, attr2: Attribute) extends Action
   case class TakeControl(player: TargetPlayer, target: TargetObject) extends Action
 
@@ -46,7 +46,7 @@ sealed trait Ability extends AstNode
   sealed trait PassiveAbility extends Ability
     case class ApplyEffect(target: TargetObjectOrCard, effect: Effect) extends PassiveAbility
     case class AttributeAdjustment(target: TargetObjectOrCard, attribute: Attribute, operation: Operation) extends PassiveAbility
-    case class FreezeAttribute(target: TargetObjectOrCard, attribute: Attribute) extends PassiveAbility
+    case class FreezeAttribute(target: Target, attribute: Attribute) extends PassiveAbility
     case class HasAbility(target: TargetObjectOrCard, ability: Ability) extends PassiveAbility
 
 sealed trait Effect extends AstNode
@@ -196,4 +196,8 @@ case class WithinDistance(spaces: Number) extends IntermediateNode
 case class AttributeOperation(op: Operation, attr: Attribute) extends IntermediateNode
 case class CardPlay(player: TargetPlayer, cardType: CardType) extends IntermediateNode
 case class RandomCards(num: Number, cardType: CardType) extends IntermediateNode
-case class TargetAttribute(target: TargetObject, attr: Attribute) extends IntermediateNode
+case class TargetAttribute(target: TargetObjectOrPlayer, attr: Attribute) extends IntermediateNode {
+  if (target.isInstanceOf[TargetPlayer] && attr != Health) {
+    throw new ClassCastException(s"expected Health, got $attr")
+  }
+}


### PR DESCRIPTION
This resolves #95 by allowing "Restore 4 health to yourself" to parse without semantic errors.

The client-side part of this is https://github.com/wordbots/wordbots-core/pull/758.