### PR TITLE
SpawnObject action; support for named generated cards

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,5 +23,7 @@ enablePlugins(BuildInfoPlugin)
 
 mainClass in Compile := Some("wordbots.Server")
 
+initialCommands in console := "import wordbots._"
+
 buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion)
 buildInfoPackage := "wordbots"

--- a/src/main/scala/wordbots/AstValidator.scala
+++ b/src/main/scala/wordbots/AstValidator.scala
@@ -158,7 +158,7 @@ object NoThis extends AstRule {
 object ValidGeneratedCard extends AstRule {
   override def validate (node: AstNode) : Try[Unit] = {
     node match {
-      case c@GeneratedCard(cardType, _) => Try {
+      case c@GeneratedCard(cardType, _, _) => Try {
         val attributes = (c.getAttributeAmount(Attack).size, c.getAttributeAmount(Health).size, c.getAttributeAmount(Speed).size)
         val expectedAttrs = cardType match {
           case Robot => (1, 1, 1)

--- a/src/main/scala/wordbots/CodeGenerator.scala
+++ b/src/main/scala/wordbots/CodeGenerator.scala
@@ -35,6 +35,7 @@ object CodeGenerator {
       case RestoreAttribute(target, Health, None) => s"(function () { actions['restoreHealth'](${g(target)}); })"
       case ReturnToHand(target) => s"(function () { actions['returnToHand'](${g(target)}); })"
       case SetAttribute(target, attr, num) => s"(function () { actions['setAttribute'](${g(target)}, ${g(attr)}, ${g(num)}); })"
+      case SpawnObject(card, dest) => s"(function () { actions['spawnObject'](${g(card)}, ${g(dest)}); })"
       case SwapAttributes(target, attr1, attr2) => s"(function () { actions['swapAttributes'](${g(target)}, ${g(attr1)}, ${g(attr2)}); })"
       case TakeControl(player, target) => s"(function () { actions['takeControl'](${g(player)}, ${g(target)}); })"
 
@@ -86,11 +87,11 @@ object CodeGenerator {
       case AllC(collection) => s"targets['all'](${g(collection)})"
       case RandomC(num, collection) => s"targets['random'](${g(num)}, ${g(collection)})"
       case CopyOfC(objToCopy) => s"targets['copyOf'](${g(objToCopy)})"
-      case card@GeneratedCard(cardType, _) =>
+      case card@GeneratedCard(cardType, _, name) =>
         val attributesObjStr = Seq(Attack, Health, Speed).map { attr =>
           s"'${attr.name}': ${card.getAttributeAmount(attr).headOption.map(g).getOrElse("null")}"
         }.mkString("{", ", ", "}")
-        s"targets['generateCard'](${g(cardType)}, $attributesObjStr)"
+        s"targets['generateCard'](${g(cardType)}, $attributesObjStr, ${name.getOrElse("")})"
 
       // Target players
       case Self => "targets['self']()"

--- a/src/main/scala/wordbots/CodeGenerator.scala
+++ b/src/main/scala/wordbots/CodeGenerator.scala
@@ -91,7 +91,7 @@ object CodeGenerator {
         val attributesObjStr = Seq(Attack, Health, Speed).map { attr =>
           s"'${attr.name}': ${card.getAttributeAmount(attr).headOption.map(g).getOrElse("null")}"
         }.mkString("{", ", ", "}")
-        s"targets['generateCard'](${g(cardType)}, $attributesObjStr, ${name.getOrElse("")})"
+        s"targets['generateCard'](${g(cardType)}, $attributesObjStr, ${name.map(n => s"'${n}'")getOrElse("null")})"
 
       // Target players
       case Self => "targets['self']()"

--- a/src/main/scala/wordbots/Lexicon.scala
+++ b/src/main/scala/wordbots/Lexicon.scala
@@ -1,7 +1,7 @@
 package wordbots
 
 import com.workday.montague.ccg._
-import com.workday.montague.parser.{AnythingMatcher, ParserDict}
+import com.workday.montague.parser.ParserDict
 import com.workday.montague.semantics._
 import com.workday.montague.semantics.FunctionReaderMacro.λ
 

--- a/src/main/scala/wordbots/Lexicon.scala
+++ b/src/main/scala/wordbots/Lexicon.scala
@@ -328,7 +328,7 @@ object Lexicon {
       (NP\Num, λ {num: Number => Spaces(num)}),
       (NP\Adj, λ {c: LessThanOrEqualTo => WithinDistance(c.num)})
     )) +
-    ("spawn" -> ((S/PP)/NP, λ {c: GeneratedCard => λ {t: TargetObject => SpawnObject(c, t)}})) +
+    (Seq("spawn", "create") -> ((S/PP)/NP, λ {c: GeneratedCard => λ {t: TargetObject => SpawnObject(c, t)}})) +
     ("speed" -> Seq(
       (N, Form(Speed): SemanticState),
       (N\Num, λ {i: Scalar => AttributeAmount(i, Speed)}),

--- a/src/main/scala/wordbots/Lexicon.scala
+++ b/src/main/scala/wordbots/Lexicon.scala
@@ -35,6 +35,7 @@ object Lexicon {
       (Num, Form(Scalar(1)): SemanticState)  // e.g. "(draw) a card"
     )) +
     ("a player" -> (NP, Form(ChooseO(ObjectsInPlay(Kernel))): SemanticState)) +
+    ("a random tile" -> (NP, Form(RandomO(Scalar(1), AllTiles)): SemanticState)) +
     ("a tile" -> (NP, Form(ChooseO(AllTiles)): SemanticState)) +
     ("activate:" -> (S/S, λ {a: Action => ActivatedAbility(a)})) +
     ("adjacent" -> Seq(
@@ -242,7 +243,7 @@ object Lexicon {
       (NP/Adj, λ {amount: Number => Life(amount)})
     )) +
     ("if" -> ((S|S)|S, λ {c: GlobalCondition => λ {a: Action => If(c, a)}})) +
-    (Seq("in", "of", "from", "into") -> (PP/NP, identity)) +
+    (Seq("in", "on", "of", "from", "into") -> (PP/NP, identity)) +
     ("instead" -> (S|S, λ {a: Action => Instead(a)})) +
     ("in combat" -> (S\S, λ {t: AfterDestroyed => AfterDestroyed(t.target, Combat)})) +
     (Seq("in play", "on the board") -> (NP\N, λ {o: ObjectType => ObjectsInPlay(o)})) +

--- a/src/main/scala/wordbots/matchers.scala
+++ b/src/main/scala/wordbots/matchers.scala
@@ -58,13 +58,15 @@ object StatsTripleMatcher extends TokenMatcher[StatsTriple] {
   * Names are encoded in base-36 so their case and spaces are preserved in tokenization.
   */
 object NameConverters {
+  val radix = 36
+
   def encodeBase36(str: String): String = {
     val bytes: Array[Byte] = str.getBytes(StandardCharsets.UTF_8)
-    new BigInteger(1, bytes).toString(36)
+    new BigInteger(1, bytes).toString(radix)
   }
 
   def decodeBase36(base36: String): String = {
-    val bytes: Array[Byte] = new BigInteger(base36, 36).toByteArray
+    val bytes: Array[Byte] = new BigInteger(base36, radix).toByteArray
     new String(bytes, StandardCharsets.UTF_8)
   }
 }

--- a/src/main/scala/wordbots/matchers.scala
+++ b/src/main/scala/wordbots/matchers.scala
@@ -1,5 +1,8 @@
 package wordbots
 
+import java.math.BigInteger
+import java.nio.charset.StandardCharsets
+
 import com.workday.montague.parser.TokenMatcher
 
 import scala.util.Try
@@ -47,6 +50,30 @@ object StatsTripleMatcher extends TokenMatcher[StatsTriple] {
     str.split("/").map(stringToOptInt) match {
       case Array(Some(attack), Some(health), Some(speed)) => Seq(StatsTriple(attack, health, speed))
       case _ => Nil
+    }
+  }
+}
+
+/**
+  * Names are encoded in base-36 so their case and spaces are preserved in tokenization.
+  */
+object NameConverters {
+  def encodeBase36(str: String): String = {
+    val bytes: Array[Byte] = str.getBytes(StandardCharsets.UTF_8)
+    new BigInteger(1, bytes).toString(36)
+  }
+
+  def decodeBase36(base36: String): String = {
+    val bytes: Array[Byte] = new BigInteger(base36, 36).toByteArray
+    new String(bytes, StandardCharsets.UTF_8)
+  }
+}
+object NameMatcher extends TokenMatcher[String] {
+  def apply(str: String): Seq[String] = {
+    if (str.startsWith("name:") && !str.contains(' ')) {
+      Seq(NameConverters.decodeBase36(str.replace("name:", "")))
+    } else {
+      Nil
     }
   }
 }

--- a/src/test/scala/wordbots/ParserSpec.scala
+++ b/src/test/scala/wordbots/ParserSpec.scala
@@ -166,6 +166,17 @@ class ParserSpec extends FlatSpec with Matchers {
       ReturnToHand(ChooseO(ObjectsInPlay(Robot)))
     parse("Return all structures to their owner's hands") shouldEqual
       ReturnToHand(ObjectsInPlay(Structure))
+
+    // New terms for alpha v0.11:
+    parse("Spawn a 1/1/1 robot named \"Test Bot\" adjacent to your kernel") shouldEqual
+      SpawnObject(
+        GeneratedCard(
+          Robot,
+          Seq(AttributeAmount(Scalar(1), Attack), AttributeAmount(Scalar(1), Health), AttributeAmount(Scalar(1), Speed)),
+          Some("Test Bot")
+        ),
+        ObjectsMatchingConditions(Kernel, List(AdjacentTo(ThisObject), ControlledBy(Self)))
+      )
   }
 
   it should "treat 'with' as 'that has'" in {

--- a/src/test/scala/wordbots/ParserSpec.scala
+++ b/src/test/scala/wordbots/ParserSpec.scala
@@ -320,6 +320,20 @@ class ParserSpec extends FlatSpec with Matchers {
 
     parse("At the start of your turn, if you have a robot on the board with 3 or more health, draw 2 cards.") shouldEqual
       TriggeredAbility(BeginningOfTurn(Self), If(CollectionExists(ObjectsMatchingConditions(Robot, List(AttributeComparison(Health, GreaterThanOrEqualTo(Scalar(3))), ControlledBy(Self)))), Draw(Self, Scalar(2))))
+
+    // New terms for alpha v0.11:
+    parse("Whenever a robot is destroyed, spawn a 2/1/1 robot named \"Zombie Bot\" on a random tile") shouldEqual
+      TriggeredAbility(
+        AfterDestroyed(AllO(ObjectsMatchingConditions(Robot, Seq())), AnyEvent),
+        SpawnObject(
+          GeneratedCard(
+            Robot,
+            Seq(AttributeAmount(Scalar(2), Attack), AttributeAmount(Scalar(1), Health), AttributeAmount(Scalar(1), Speed)),
+            Some("Zombie Bot")
+          ),
+          RandomO(Scalar(1), AllTiles)
+        )
+      )
   }
 
   it should "understand that terms like 'a robot' suggest choosing a target in action text but NOT in trigger text" in {


### PR DESCRIPTION
This PR involves everything necessary to parse `"Spawn a 1/1/1 robot named "Test Bot" adjacent to your kernel"`:
- Special handling of `named ".*"` in the tokenizer
- a new `NameMatcher`
- a `SpawnObject` action and support for an optional `name` field in `GeneratedCard`
- lexicon rules for `"named"`, `"spawn"`, and `"a random tile"`
- a new lexicon rule for `"adjacent to"`
- two parser tests 

I haven't really thought about validation yet, but I will probably want to add a rule to ensure that spawned objects must have a name, as well as maybe a rule to make sure that you can't spawn an object onto on something that could be tile (as opposed to, like, `"Spawn a 1/1/1 robots on your kernel"`)?