### PR TITLE
Basic validation for SpawnObject action

### DIFF
--- a/src/main/scala/wordbots/AstValidator.scala
+++ b/src/main/scala/wordbots/AstValidator.scala
@@ -156,7 +156,7 @@ object NoThis extends AstRule {
 
 /** Validates that generated cards have exactly one of each desired attribute. */
 object ValidGeneratedCard extends AstRule {
-  override def validate (node: AstNode) : Try[Unit] = {
+  override def validate(node: AstNode): Try[Unit] = {
     node match {
       case c@GeneratedCard(cardType, _, _) => Try {
         val attributes = (c.getAttributeAmount(Attack).size, c.getAttributeAmount(Health).size, c.getAttributeAmount(Speed).size)
@@ -180,15 +180,17 @@ object ValidGeneratedCard extends AstRule {
 /** Validates that the destination of a SpawnObject action is something that *could* be an empty tile. */
 object ValidDestForSpawnObject extends AstRule {
   override def validate(node: AstNode): Try[Unit] = {
-    case SpawnObject(_, dest) =>
-      dest match {
-        case ChooseO(c) => validateCollectionCouldBeAnEmptyTile(c)
-        case AllO(c) => validateCollectionCouldBeAnEmptyTile(c)
-        case RandomO(_, c) => validateCollectionCouldBeAnEmptyTile(c)
-        case SavedTargetObject => Success()
-        case _ => Failure(ValidationError(s"Not a valid destination for SpawnObject: $dest"))
-      }
-    case n: AstNode => validateChildren(this, n)
+    node match {
+      case SpawnObject(_, dest) =>
+        dest match {
+          case ChooseO(c) => validateCollectionCouldBeAnEmptyTile(c)
+          case AllO(c) => validateCollectionCouldBeAnEmptyTile(c)
+          case RandomO(_, c) => validateCollectionCouldBeAnEmptyTile(c)
+          case SavedTargetObject => Success()
+          case _ => Failure(ValidationError(s"Not a valid destination for SpawnObject: $dest"))
+        }
+      case n: AstNode => validateChildren(this, n)
+    }
   }
 
   def validateCollectionCouldBeAnEmptyTile(collection: ObjectCollection): Try[Unit] = collection match {

--- a/src/main/scala/wordbots/semantics.scala
+++ b/src/main/scala/wordbots/semantics.scala
@@ -34,7 +34,11 @@ sealed trait Action extends AstNode
   case class ReturnToHand(target: TargetObject) extends Action
   case class RestoreAttribute(target: TargetObjectOrPlayer, attribute: Attribute, num: Option[Number] = None) extends Action
   case class SetAttribute(target: TargetObjectOrPlayer, attribute: Attribute, num: Number) extends Action
-  case class SpawnObject(target: GeneratedCard, dest: TargetObject) extends Action
+  case class SpawnObject(target: GeneratedCard, dest: TargetObject) extends Action {
+    if (target.name.isEmpty) {
+      throw new ClassCastException("SpawnObject requires a GeneratedCard with a name")
+    }
+  }
   case class SwapAttributes(target: TargetObject, attr1: Attribute, attr2: Attribute) extends Action
   case class TakeControl(player: TargetPlayer, target: TargetObject) extends Action
 


### PR DESCRIPTION
#103. (Followup to #102.)

Ensure that SpawnObject actions:
- spawn a card with a name.
- spawn to a destination that could be an empty tile.