### PR TITLE
More robust handling of AST validation

### DIFF
--- a/src/main/scala/wordbots/AstValidator.scala
+++ b/src/main/scala/wordbots/AstValidator.scala
@@ -80,7 +80,7 @@ object NoUnimplementedRules extends AstRule {
 }
 
 /**
- * Disallow the following behaviors within a triggered ability (excepted AfterPlayed, which can be treated more like an action):
+ * Disallow the following behaviors within a triggered ability or conditional action (except AfterPlayed trigger, which can be treated more like an action):
  *    * choosing targets (because there's no UI support for having a player choose targets during event execution)
  *    * rewriting card text (because calling the parser is expensive and should only happen from direct player interaction)
  */
@@ -101,13 +101,14 @@ object NoChooseOrRewriteInTriggeredAction extends AstRule {
     node match {
       case TriggeredAbility(AfterPlayed(_), _) => Success()  // Choosing targets and rewriting text *is* allowed for AfterPlayed triggers.
       case TriggeredAbility(_, _) => validateChildren(NoChooseTargetOrRewrite, node)  // (but not for any other trigger).
+      case ConditionalAction(_, _) => validateChildren(NoChooseTargetOrRewrite, node)
       case n: AstNode => validateChildren(this, n)
     }
   }
 }
 
 /**
- * Disallow paying energy within triggered abilities,
+ * Disallow paying energy within triggered abilities or conditional actions,
  * because there's no gameplay support for "rolling back" the action triggered if there's not enough energy to pay.
  */
 object NoPayEnergyInTriggeredAction extends AstRule {
@@ -123,6 +124,7 @@ object NoPayEnergyInTriggeredAction extends AstRule {
   override def validate(node: AstNode): Try[Unit] = {
     node match {
       case TriggeredAbility(_, _) => validateChildren(NoPayEnergy, node)
+      case ConditionalAction(_, _) => validateChildren(NoPayEnergy, node)
       case n: AstNode => validateChildren(this, n)
     }
   }

--- a/src/main/scala/wordbots/Lexicon.scala
+++ b/src/main/scala/wordbots/Lexicon.scala
@@ -65,6 +65,12 @@ object Lexicon {
       (NP/NP, λ {c: TilesMatchingConditions => TilesMatchingConditions(Seq(AdjacentTo(ThisObject)) ++ c.conditions)})
     )) +
     ("adjacent tile" -> (NP, TilesMatchingConditions(Seq(AdjacentTo(They))): Sem)) +  // e.g. "Move each robot to a random adjacent tile."
+    ("adjacent to" -> Seq(
+      (PP/NP, λ {t: TargetObjectOrTile => AdjacentTo(t)}),
+      (PP/NP, λ {t: TargetObject => ChooseT(TilesMatchingConditions(Seq(AdjacentTo(t))))}),
+      ((NP/NP)\N, λ {o: ObjectType => λ {t: TargetObjectOrTile => ObjectsMatchingConditions(o, Seq(AdjacentTo(t)))}}),
+      (PP/NP, λ {c: ObjectsMatchingConditions => ObjectsMatchingConditions(c.objectType, Seq(AdjacentTo(ThisObject)) ++ c.conditions)})
+    )) +
     ("is" / Seq("adjacent to", "adjacent to a", "adjacent to an") -> Seq(
       ((S\NP)/N, λ {t: ObjectType => λ {o: TargetObject => CollectionExists(ObjectsMatchingConditions(t, Seq(AdjacentTo(o))))}}),
       ((S\N)/NP, λ {o: TargetObject => λ {e: EnemyObject => CollectionExists(ObjectsMatchingConditions(e.objectType, Seq(AdjacentTo(o), ControlledBy(Opponent))))}}),
@@ -74,12 +80,6 @@ object Lexicon {
       ((S\NP)/N, λ {t: ObjectType => λ {o: TargetObject => NotGC(CollectionExists(ObjectsMatchingConditions(t, Seq(AdjacentTo(o)))))}}),
       ((S\N)/NP, λ {o: TargetObject => λ {e: EnemyObject => NotGC(CollectionExists(ObjectsMatchingConditions(e.objectType, Seq(AdjacentTo(o), ControlledBy(Opponent)))))}}),
       ((S\NP)/NP, λ {c: ObjectsMatchingConditions => λ {o: TargetObject => NotGC(CollectionExists(ObjectsMatchingConditions(c.objectType, c.conditions :+ AdjacentTo(o))))}})
-    )) +
-    ("adjacent to" -> Seq(
-      (PP/NP, λ {t: TargetObjectOrTile => AdjacentTo(t)}),
-      (PP/NP, λ {t: TargetObject => ChooseT(TilesMatchingConditions(Seq(AdjacentTo(t))))}),
-      ((NP/NP)\N, λ {o: ObjectType => λ {t: TargetObjectOrTile => ObjectsMatchingConditions(o, Seq(AdjacentTo(t)))}}),
-      (PP/NP, λ {c: ObjectsMatchingConditions => ObjectsMatchingConditions(c.objectType, Seq(AdjacentTo(ThisObject)) ++ c.conditions)})
     )) +
     ("after attacking" -> (S\S, λ {a: Action => TriggeredAbility(AfterAttack(ThisObject, AllObjects), a)})) +
     (Seq("all", "each", "every") -> Seq( // Also see Seq("each", "every") below for definitions that DON'T apply to "all".

--- a/src/main/scala/wordbots/Lexicon.scala
+++ b/src/main/scala/wordbots/Lexicon.scala
@@ -65,19 +65,21 @@ object Lexicon {
       (NP/NP, λ {c: TilesMatchingConditions => TilesMatchingConditions(Seq(AdjacentTo(ThisObject)) ++ c.conditions)})
     )) +
     ("adjacent tile" -> (NP, TilesMatchingConditions(Seq(AdjacentTo(They))): Sem)) +  // e.g. "Move each robot to a random adjacent tile."
+    ("is" / Seq("adjacent to", "adjacent to a", "adjacent to an") -> Seq(
+      ((S\NP)/N, λ {t: ObjectType => λ {o: TargetObject => CollectionExists(ObjectsMatchingConditions(t, Seq(AdjacentTo(o))))}}),
+      ((S\N)/NP, λ {o: TargetObject => λ {e: EnemyObject => CollectionExists(ObjectsMatchingConditions(e.objectType, Seq(AdjacentTo(o), ControlledBy(Opponent))))}}),
+      ((S\NP)/NP, λ {c: ObjectsMatchingConditions => λ {o: TargetObject => CollectionExists(ObjectsMatchingConditions(c.objectType, c.conditions :+ AdjacentTo(o)))}})
+    )) +
+    ("is not" / Seq("adjacent to", "adjacent to a", "adjacent to an") -> Seq(
+      ((S\NP)/N, λ {t: ObjectType => λ {o: TargetObject => NotGC(CollectionExists(ObjectsMatchingConditions(t, Seq(AdjacentTo(o)))))}}),
+      ((S\N)/NP, λ {o: TargetObject => λ {e: EnemyObject => NotGC(CollectionExists(ObjectsMatchingConditions(e.objectType, Seq(AdjacentTo(o), ControlledBy(Opponent)))))}}),
+      ((S\NP)/NP, λ {c: ObjectsMatchingConditions => λ {o: TargetObject => NotGC(CollectionExists(ObjectsMatchingConditions(c.objectType, c.conditions :+ AdjacentTo(o))))}})
+    )) +
     ("adjacent to" -> Seq(
       (PP/NP, λ {t: TargetObjectOrTile => AdjacentTo(t)}),
       (PP/NP, λ {t: TargetObject => ChooseT(TilesMatchingConditions(Seq(AdjacentTo(t))))}),
       ((NP/NP)\N, λ {o: ObjectType => λ {t: TargetObjectOrTile => ObjectsMatchingConditions(o, Seq(AdjacentTo(t)))}}),
       (PP/NP, λ {c: ObjectsMatchingConditions => ObjectsMatchingConditions(c.objectType, Seq(AdjacentTo(ThisObject)) ++ c.conditions)})
-    )) +
-    ("is" /?/ Seq("adjacent to", "adjacent to a", "adjacent to an") -> Seq(
-      ((S\N)/NP, λ {o: TargetObject => λ {e: EnemyObject => CollectionExists(ObjectsMatchingConditions(e.objectType, Seq(AdjacentTo(o), ControlledBy(Opponent))))}}),
-      ((S\NP)/NP, λ {c: ObjectsMatchingConditions => λ {o: TargetObject => CollectionExists(ObjectsMatchingConditions(c.objectType, c.conditions :+ AdjacentTo(o)))}})
-    )) +
-    ("is not" /?/ Seq("adjacent to", "adjacent to a", "adjacent to an") -> Seq(
-      ((S\N)/NP, λ {o: TargetObject => λ {e: EnemyObject => NotGC(CollectionExists(ObjectsMatchingConditions(e.objectType, Seq(AdjacentTo(o), ControlledBy(Opponent)))))}}),
-      ((S\NP)/NP, λ {c: ObjectsMatchingConditions => λ {o: TargetObject => NotGC(CollectionExists(ObjectsMatchingConditions(c.objectType, c.conditions :+ AdjacentTo(o))))}})
     )) +
     ("after attacking" -> (S\S, λ {a: Action => TriggeredAbility(AfterAttack(ThisObject, AllObjects), a)})) +
     (Seq("all", "each", "every") -> Seq( // Also see Seq("each", "every") below for definitions that DON'T apply to "all".

--- a/src/main/scala/wordbots/Parser.scala
+++ b/src/main/scala/wordbots/Parser.scala
@@ -1,7 +1,7 @@
 package wordbots
 
 import com.workday.montague.ccg._
-import com.workday.montague.parser.{ParserDict, SemanticParseResult, SemanticParser}
+import com.workday.montague.parser.{ParserDict, SemanticParseNode, SemanticParseResult, SemanticParser}
 import com.workday.montague.semantics._
 
 import scala.language.postfixOps
@@ -18,8 +18,11 @@ object Parser extends SemanticParser[CcgCat](Lexicon.lexicon) {
     val input = args.mkString(" ")
     val result: SemanticParseResult[CcgCat] = parse(input)
 
-    val output: String = result.bestParse.map(p => s"${p.semantic.toString} [${p.syntactic.toString}]").getOrElse("(failed to parse)")
-    val code: Try[String] = Try { result.bestParse.get.semantic }.flatMap {
+    val bestParse: Option[SemanticParseNode[CcgCat]] = ErrorAnalyzer.bestValidParse(result)
+    val allSemanticallyCompleteParses: List[String] = result.semanticCompleteParses.map(p => s"${p.semantic.toString} [${p.syntactic.toString}]")
+
+    val output: String = bestParse.map(p => s"${p.semantic.toString} [${p.syntactic.toString}]").getOrElse("(failed to parse)")
+    val code: Try[String] = Try { bestParse.get.semantic }.flatMap {
       case Form(v: Semantics.AstNode) => CodeGenerator.generateJS(v)
       case _ => Failure(new RuntimeException("Parser did not produce a valid expression"))
     }
@@ -28,12 +31,13 @@ object Parser extends SemanticParser[CcgCat](Lexicon.lexicon) {
     println(s"Input: $input")
     println(s"Tokens: ${tokenizer(input).mkString("[\"", "\", \"", "\"]")}")
     println(s"Parse result: $output")
-    println(s"Error diagnosis: ${ErrorAnalyzer.diagnoseError(input, result.bestParse)}")
+    println(s"All semantically complete parse results:\n  ${allSemanticallyCompleteParses.mkString("\n  ")}")
+    println(s"Error diagnosis: ${ErrorAnalyzer.diagnoseError(input, bestParse)}")
     println(s"Generated JS code: ${code.getOrElse(code.failed.get)}")
     // scalastyle:on regex
 
     // For debug purposes, output the best parse tree (if one exists) to SVG.
-    //result.bestParse.foreach(result => new java.io.PrintWriter("test.svg") { write(result.toSvg); close() })
+    //bestParse.foreach(result => new java.io.PrintWriter("test.svg") { write(result.toSvg); close() })
   }
 
   /** Parses the input. */

--- a/src/main/scala/wordbots/Server.scala
+++ b/src/main/scala/wordbots/Server.scala
@@ -2,7 +2,7 @@ package wordbots
 
 import com.roundeights.hasher.Implicits._
 import com.workday.montague.ccg.CcgCat
-import com.workday.montague.parser.SemanticParseNode
+import com.workday.montague.parser.{SemanticParseNode, SemanticParseResult}
 import com.workday.montague.semantics.{Form, SemanticState}
 import org.http4s.{Response => H4sResponse, _}
 import org.http4s.circe._
@@ -12,6 +12,7 @@ import org.http4s.server.blaze.BlazeBuilder
 import io.circe._
 import io.circe.generic.auto._
 import io.circe.syntax._
+import org.log4s.MDC.result
 import scalaz.Memo
 import scalaz.concurrent.Task
 import wordbots.Semantics.AstNode
@@ -51,25 +52,26 @@ object MemoParser {
       case _ => ValidateUnknownCard
     }
 
-    val result = Parser.parse(input).bestParse
-    val parsedTokens = {
-      result.toSeq
+    val parseResult: SemanticParseResult[CcgCat] = Parser.parse(input)
+    val bestParse: Option[SemanticParseNode[CcgCat]] = ErrorAnalyzer.bestValidParse(parseResult)
+    val parsedTokens: Seq[String] = {
+      bestParse.toSeq
         .flatMap(_.terminals)
         .flatMap(_.parseTokens)
         .map(_.tokenString)
         .filter(token => Lexicon.listOfTerms.contains(token) && token != "\"")
     }
-    val unrecognizedTokens = ErrorAnalyzer.findUnrecognizedTokens(input)
+    val unrecognizedTokens: Seq[String] = ErrorAnalyzer.findUnrecognizedTokens(input)
 
-    ErrorAnalyzer.diagnoseError(input, result, fastErrorAnalysisMode) match {
+    ErrorAnalyzer.diagnoseError(input, bestParse, fastErrorAnalysisMode) match {
       case Some(error) =>
         print("  [F]")
         FailedParse(error, unrecognizedTokens)
       case None =>
-        result.map(_.semantic) match {
+        bestParse.map(_.semantic) match {
           case Some(Form(ast: AstNode)) =>
             print("  [S]")
-            SuccessfulParse(result.get, ast, parsedTokens)
+            SuccessfulParse(bestParse.get, ast, parsedTokens)
           case _ =>
             print("  [F]")
             FailedParse(ParserError("Unspecified parser error"), unrecognizedTokens)

--- a/src/test/scala/wordbots/ErrorAnalyzerSpec.scala
+++ b/src/test/scala/wordbots/ErrorAnalyzerSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest._
 
 class ErrorAnalyzerSpec extends FlatSpec with Matchers {
   def analyze(input: String): Option[ParserError] = {
-    val parseResult = Parser.parse(input).bestParse
+    val parseResult = ErrorAnalyzer.bestValidParse(Parser.parse(input))
     ErrorAnalyzer.diagnoseError(input, parseResult)
   }
 


### PR DESCRIPTION
(Fixes #257)

* Introduces `ErrorAnalyzer.bestValidParse()`, which wraps `SemanticParseResult.bestParse` and additionally prefers parses that pass the AstValidator, if any (this resolves issues where the "best" parse fails the AstValidator but there is actually a passing parse further down)
* Use `ErrorAnalyzer.bestValidParse` everywhere we run the parser (server, console, tests)
* Treat `ConditionalAction` the same as `TriggeredAbility` for certain AST validation rules (fixes an edge-case bug caught by test suite where "When this robot is destroyed, destroy a robot" has two valid parses, one as `TriggeredAbility` and one as `ConditionalAction`)
* Parse "if this robot is not adjacent to an object" correctly (returning a parse that doesn't violate AST validation)